### PR TITLE
Add HTTP Connection cache

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.7, '3.0']
     steps:
       - uses: actions/checkout@v2
       - name: Set up CouchDB

--- a/couchrest.gemspec
+++ b/couchrest.gemspec
@@ -27,11 +27,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.summary = %q{Lean and RESTful interface to CouchDB.}
 
-  s.add_dependency "httpclient", ["~> 2.8"]
+  s.add_dependency "httpx", ["~> 0.18"]
   s.add_dependency "multi_json", ["~> 1.7"]
   s.add_dependency "mime-types", [">= 1.15"]
 
-  s.add_development_dependency "bundler" #, "~> 1.3"
+  s.add_development_dependency "bundler"
   # s.add_development_dependency "json", ">= 2.0.1"
   s.add_development_dependency "rspec", "~> 2.14.1"
   s.add_development_dependency "rake", "< 11.0"

--- a/lib/couchrest.rb
+++ b/lib/couchrest.rb
@@ -14,7 +14,7 @@
 
 require 'multi_json'
 require 'mime/types'
-require 'httpclient'
+require 'httpx'
 
 $:.unshift File.dirname(__FILE__) unless
  $:.include?(File.dirname(__FILE__)) ||

--- a/lib/couchrest/connection.rb
+++ b/lib/couchrest/connection.rb
@@ -188,7 +188,6 @@ module CouchRest
 
     # Send request, and leave a reference to the response for debugging purposes
     def send_request(req, &block)
-      # require 'byebug'; byebug
       @last_response = @http.request(
         req[:method].downcase, 
         req[:uri], 

--- a/lib/couchrest/connection.rb
+++ b/lib/couchrest/connection.rb
@@ -207,7 +207,7 @@ module CouchRest
       @last_response = @http.request(
         req[:method].downcase, 
         req[:uri], 
-        {
+        **{
           ssl: @ssl_options, 
           body: req[:body],
           headers: req[:header]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 require "rubygems"
 require "rspec"
 require "webmock/rspec"
+require "httpx/adapters/webmock"
 
 require File.join(File.dirname(__FILE__), '..','lib','couchrest')
 # check the following file to see how to use the spec'd features.


### PR DESCRIPTION
only use one connection per thread, taking into account various connection options such as proxy, authorization, ssl, timeouts.
    
based on #1